### PR TITLE
Add repository/homepage/bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,14 @@
     "type-coverage": "type-coverage",
     "typecheck": "tsc --noEmit"
   },
+  "homepage": "https://github.com/mozilla/addons-scanner-utils",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozilla/addons-scanner-utils.git"
+  },
+  "bugs": {
+    "url": "http://github.com/mozilla/addons-scanner-utils/issues"
+  },
   "typeCoverage": {
     "atLeast": 97
   }


### PR DESCRIPTION
The package’s npm page lacks any link to the repository: https://www.npmjs.com/package/addons-scanner-utils

I copied this format and position directly from web-ext: https://github.com/mozilla/web-ext/blob/629aa142a6e643977fe6c94eb3f9d1fed8c6e3f0/package.json#L39-L46