### PR TITLE
Use Node 14 and 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ references:
     working_directory: ~/addons-scanner-utils
     docker:
       # This is the NodeJS version we run in production.
-      - image: circleci/node:12
+      - image: circleci/node:14
 
   defaults-next: &defaults-next
     working_directory: ~/addons-scanner-utils
     docker:
       # This is the next NodeJS version we will support.
-      - image: circleci/node:14
+      - image: circleci/node:16
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-scanner-utils/issues/172

---

We use Node 14 on production (AMO) so this patch updates the Node versions used in CI to be consistent.