### PR TITLE
mark peerDependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,23 @@
     "express": "4.18.1",
     "safe-compare": "1.1.4"
   },
+  "peerDependenciesMeta": {
+    "@types/download": {
+      "optional": true
+    },
+    "body-parser": {
+      "optional": true
+    },
+    "download": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    },
+    "safe-compare": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/download": "8.0.1",


### PR DESCRIPTION
As mentioned in this issue: https://github.com/mozilla/web-ext/issues/2432
I have tested locally by cloning `web-ext` and `addons-linter` and changing dependencies to use local versions using `file:./../addons-linter` and `file:./../addons-scanner-utils` respectively, and peer dependency warnings no longer appear when using `pnpm` or `yarn`.
