### PR TITLE
Use Node 16 and Node 18 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ references:
     working_directory: ~/addons-scanner-utils
     docker:
       # This is the NodeJS version we run in production.
-      - image: cimg/node:14.21
+      - image: cimg/node:16.19
 
   defaults-next: &defaults-next
     working_directory: ~/addons-scanner-utils
     docker:
       # This is the next NodeJS version we will support.
-      - image: cimg/node:16.19
+      - image: cimg/node:18.15
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Now that `web-ext` requires Node 16, it is safe to bump the Node versions in this project.