### PR TITLE
peerDeps: node-fetch@2.6.7->2.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "body-parser": "1.20.2",
     "express": "4.18.2",
-    "node-fetch": "2.6.7",
+    "node-fetch": "2.6.11",
     "safe-compare": "1.1.4"
   },
   "peerDependenciesMeta": {
@@ -42,7 +42,7 @@
     "@types/express": "4.17.17",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.1.1",
-    "@types/node-fetch": "^2.6.2",
+    "@types/node-fetch": "^2.6.4",
     "@types/safe-compare": "^1.1.0",
     "@types/sinon": "^10.0.0",
     "@types/supertest": "^2.0.8",
@@ -54,7 +54,7 @@
     "eslint-plugin-amo": "^1.10.2",
     "express": "4.18.2",
     "jest": "^29.0.0",
-    "node-fetch": "2.6.7",
+    "node-fetch": "2.6.11",
     "prettier": "2.8.8",
     "pretty-quick": "^3.0.0",
     "rimraf": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,10 +795,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node-fetch@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
-  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+"@types/node-fetch@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.4.tgz#1bc3a26de814f6bf466b25aeb1473fa1afe6a660"
+  integrity sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -3501,10 +3501,10 @@ nise@^5.1.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Bump this pinned dependency (it seems to be idiomatic for this package - I'd consider switching to a range: `^2.6.11) to resolve security issue and global-handling bug.

- Release notes: https://github.com/node-fetch/node-fetch/releases
- Package diff: https://npm-diff.app/node-fetch@2.6.7...node-fetch@2.6.11
