### PR TITLE
deps: move @types/yauzl from deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "Mozilla Add-ons Team",
   "license": "MPL-2.0",
   "dependencies": {
-    "@types/yauzl": "2.10.3",
     "common-tags": "1.8.2",
     "first-chunk-stream": "3.0.0",
     "strip-bom-stream": "4.0.0",
@@ -46,6 +45,7 @@
     "@types/safe-compare": "^1.1.0",
     "@types/sinon": "^21.0.0",
     "@types/supertest": "^6.0.2",
+    "@types/yauzl": "2.10.3",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
     "body-parser": "2.2.2",


### PR DESCRIPTION
Was originally moved to runtime dependencies in 7fd46802eb2fb8ef6f2f93232a77c35c81d8b641.

Seems safe and idiomatic to move it back with the other typings packages.