### PR TITLE
Concat all buffers at once at end

### DIFF
--- a/src/io/xpi.ts
+++ b/src/io/xpi.ts
@@ -187,13 +187,14 @@ export class Xpi extends IOBase {
     const fileStream = await this.getFileAsStream(path);
 
     return new Promise((resolve, reject) => {
-      let buf = Buffer.from('');
+      const chunks: Uint8Array[] = [];
       fileStream.on('data', (chunk: Uint8Array) => {
-        buf = Buffer.concat([buf, chunk]);
+        chunks.push(chunk);
       });
 
       // Once the file is assembled, resolve the promise.
       fileStream.on('end', () => {
+        const buf = Buffer.concat(chunks);
         const fileString = buf.toString('utf8');
         resolve(fileString);
       });


### PR DESCRIPTION
This PR optimizes performance of reading a file by concatenating all buffers at the end. This reduces time taken on buffer reallocation, especially for huge files.

### Background
When attempting to upload an extension with a huge file (~100MB), the linter server timed out after 6min. (https://github.com/mozilla/addons/issues/1590) This PR will fix such issues.

### Performance
I tested the performance improvements that this PR brings to `addons-linter` tool.
- Add-on file: the file attached in above issue, which is 50MB zipped, 126MB unzipped, and contains a 104MB wasm file
- Machine: Macbook Air M1
- OS X, Node 20
- Command: `time addons-linter addon.zip`

Before this PR, it took 203s for the linter to finish. After this PR, the time has decreased to 3.7s. (98% improvement)