### PR TITLE
Bump Node.js to 20.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ references:
     working_directory: ~/addons-scanner-utils
     docker:
       # This is the next NodeJS version we will support.
-      - image: cimg/node:22.18
+      - image: cimg/node:22.14
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Part of https://github.com/mozilla/addons/issues/15266

Testing with Node 20 and 22 - the linter will eventually migrate away from Node 18.