### PR TITLE
Make the request body limit configurable, and bump its default value to 1mb

### DIFF
--- a/src/functions/index.spec.ts
+++ b/src/functions/index.spec.ts
@@ -58,6 +58,7 @@ describe(__filename, () => {
       _console,
       apiKey = 'valid api key',
       apiKeyEnvVarName = 'API_KEY',
+      maxRequestBodySize,
     }: Partial<
       FunctionConfig & { apiKey: string; allowedOrigin: string }
     > = {}) => {
@@ -67,6 +68,7 @@ describe(__filename, () => {
         _console,
         _process,
         apiKeyEnvVarName,
+        maxRequestBodySize,
       });
 
       return (handler: express.Handler) => ({
@@ -267,6 +269,16 @@ describe(__filename, () => {
         .send(JSON.stringify(body, null, 4));
 
       expect(response.status).toEqual(200);
+    });
+
+    it('returns a 413 when the request body exceeds the configured limit', async () => {
+      const { app, sendApiKey } = _createExpressApp({ maxRequestBodySize: 1 })(
+        okHandler,
+      );
+
+      const response = await sendApiKey(request(app).post('/'));
+
+      expect(response.status).toEqual(413);
     });
   });
 });

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -28,11 +28,15 @@ export type RequestWithExtraProps = Request & {
  * @property _process - Process object for environment variables (for testing
  *   purposes)
  * @property apiKeyEnvVarName - Environment variable name for the API key
+ * @property maxRequestBodySize - Controls the maximum request body size. If
+ *   this is a number, then the value specifies the number of bytes; if it is a
+ *   string, the value is passed to the bytes library for parsing.
  */
 export type FunctionConfig = {
   _console?: typeof console;
   _process?: typeof process;
   apiKeyEnvVarName?: string;
+  maxRequestBodySize?: string | number;
 };
 
 /**
@@ -62,6 +66,7 @@ export const createExpressApp =
     _console = console,
     _process = process,
     apiKeyEnvVarName = 'LAMBDA_API_KEY',
+    maxRequestBodySize = '1mb',
   }: FunctionConfig = {}) =>
   (handler: RequestHandler) => {
     const app = express();
@@ -75,6 +80,7 @@ export const createExpressApp =
 
     // This is the options we pass to the `json()` middleware.
     const jsonOptions = {
+      limit: maxRequestBodySize,
       // This is a hack to retain the raw body on the request object. We need
       // this to verify the signature of the request.
       verify(


### PR DESCRIPTION
refs https://github.com/mozilla/addons/issues/16203

---

This allows scanners to change the max request body limit, and it also sets a sensitive default value.