### PR TITLE
Add a postScannerResult function

### DIFF
--- a/src/functions/api.spec.ts
+++ b/src/functions/api.spec.ts
@@ -1,13 +1,13 @@
-import { patchScannerResult } from './api';
+import { patchScannerResult, postScannerResult } from './api';
 
 describe(__filename, () => {
-  describe('patchScannerResult', () => {
-    const issKey = 'test-iss-key';
-    const secret = 'test-secret';
-    const env = { AMO_JWT_ISS_KEY: issKey, AMO_JWT_SECRET: secret };
-    const url = 'https://addons.mozilla.org/api/v5/scanner/results/1/';
-    const payload = { results: { version: '1.2.3', matchedRules: [] } };
+  const issKey = 'test-iss-key';
+  const secret = 'test-secret';
+  const env = { AMO_JWT_ISS_KEY: issKey, AMO_JWT_SECRET: secret };
+  const url = 'https://addons.mozilla.org/api/v5/scanner/results/1/';
+  const payload = { results: { version: '1.2.3', matchedRules: [] } };
 
+  describe('patchScannerResult', () => {
     it('sends a PATCH request with correct headers and body', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -47,6 +47,50 @@ describe(__filename, () => {
     it('throws when AMO_JWT_SECRET is not set', async () => {
       await expect(
         patchScannerResult({ url, payload, env: { AMO_JWT_ISS_KEY: issKey } }),
+      ).rejects.toThrow('AMO_JWT_SECRET environment variable is not set');
+    });
+  });
+
+  describe('postScannerResult', () => {
+    it('sends a POST request with correct headers and body', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+      });
+
+      await postScannerResult({ url, payload, env });
+
+      const [calledURL, calledOptions] = (global.fetch as jest.Mock).mock
+        .calls[0];
+      expect(calledURL).toEqual(url);
+      expect(calledOptions.method).toEqual('POST');
+      expect(calledOptions.headers['Content-Type']).toEqual('application/json');
+      expect(calledOptions.headers.Authorization).toMatch(/^JWT /);
+      expect(calledOptions.body).toEqual(JSON.stringify(payload));
+    });
+
+    it('throws AMOError when response is not ok', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+      });
+
+      await expect(postScannerResult({ url, payload, env })).rejects.toThrow(
+        'unexpected response: Unprocessable Entity',
+      );
+    });
+
+    it('throws when AMO_JWT_ISS_KEY is not set', async () => {
+      await expect(
+        postScannerResult({ url, payload, env: { AMO_JWT_SECRET: secret } }),
+      ).rejects.toThrow('AMO_JWT_ISS_KEY environment variable is not set');
+    });
+
+    it('throws when AMO_JWT_SECRET is not set', async () => {
+      await expect(
+        postScannerResult({ url, payload, env: { AMO_JWT_ISS_KEY: issKey } }),
       ).rejects.toThrow('AMO_JWT_SECRET environment variable is not set');
     });
   });

--- a/src/functions/api.ts
+++ b/src/functions/api.ts
@@ -13,6 +13,17 @@ export type PatchScannerResultParams = MakeJWTConfig & {
 };
 
 /**
+ * Parameters for posting a scanner result.
+ *
+ * @property url - URL to POST
+ * @property payload - JSON body to send
+ */
+export type PostScannerResultParams = MakeJWTConfig & {
+  url: string;
+  payload: Record<string, unknown>;
+};
+
+/**
  * PATCH a scanner result to the AMO API, authenticating with a JWT token
  * computed from the `AMO_JWT_ISS_KEY` and `AMO_JWT_SECRET` environment
  * variables.
@@ -26,6 +37,32 @@ export const patchScannerResult = async ({
 }: PatchScannerResultParams): Promise<void> => {
   const response = await fetch(url, {
     method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `JWT ${makeJWT({ env })}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new AMOError(`unexpected response: ${response.statusText}`);
+  }
+};
+
+/**
+ * POST a scanner result to the AMO API, authenticating with a JWT token
+ * computed from the `AMO_JWT_ISS_KEY` and `AMO_JWT_SECRET` environment
+ * variables.
+ *
+ * @throws AMOError if the response is not ok
+ */
+export const postScannerResult = async ({
+  url,
+  payload,
+  env,
+}: PostScannerResultParams): Promise<void> => {
+  const response = await fetch(url, {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `JWT ${makeJWT({ env })}`,


### PR DESCRIPTION
Another shared helper, very similar to `patchScannerResult` (for now).