### PR TITLE
Add support for the X-AMO-Request-ID header

### DIFF
--- a/src/functions/api.spec.ts
+++ b/src/functions/api.spec.ts
@@ -1,4 +1,8 @@
 import { patchScannerResult, postScannerResult } from './api';
+import {
+  AMO_REQUEST_ID_HEADER,
+  requestContextStorage,
+} from './request-context';
 
 describe(__filename, () => {
   const issKey = 'test-iss-key';
@@ -24,6 +28,35 @@ describe(__filename, () => {
       expect(calledOptions.headers['Content-Type']).toEqual('application/json');
       expect(calledOptions.headers.Authorization).toMatch(/^JWT /);
       expect(calledOptions.body).toEqual(JSON.stringify(payload));
+    });
+
+    it('sends the X-AMO-Request-ID header when a request ID is in scope', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const requestId = 'req-123';
+      await requestContextStorage.run({ requestId }, () =>
+        patchScannerResult({ url, payload, env }),
+      );
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers[AMO_REQUEST_ID_HEADER]).toEqual(requestId);
+    });
+
+    it('does not send the X-AMO-Request-ID header without a request ID', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await patchScannerResult({ url, payload, env });
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers).not.toHaveProperty(AMO_REQUEST_ID_HEADER);
     });
 
     it('throws AMOError when response is not ok', async () => {
@@ -68,6 +101,35 @@ describe(__filename, () => {
       expect(calledOptions.headers['Content-Type']).toEqual('application/json');
       expect(calledOptions.headers.Authorization).toMatch(/^JWT /);
       expect(calledOptions.body).toEqual(JSON.stringify(payload));
+    });
+
+    it('sends the X-AMO-Request-ID header when a request ID is in scope', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+      });
+
+      const requestId = 'req-123';
+      await requestContextStorage.run({ requestId }, () =>
+        postScannerResult({ url, payload, env }),
+      );
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers[AMO_REQUEST_ID_HEADER]).toEqual(requestId);
+    });
+
+    it('does not send the X-AMO-Request-ID header without a request ID', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+      });
+
+      await postScannerResult({ url, payload, env });
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers).not.toHaveProperty(AMO_REQUEST_ID_HEADER);
     });
 
     it('throws AMOError when response is not ok', async () => {

--- a/src/functions/api.ts
+++ b/src/functions/api.ts
@@ -1,5 +1,6 @@
 import { AMOError } from './error';
 import { makeJWT, MakeJWTConfig } from './auth';
+import { withRequestIdHeader } from './request-context';
 
 /**
  * Parameters for patching a scanner result.
@@ -37,10 +38,10 @@ export const patchScannerResult = async ({
 }: PatchScannerResultParams): Promise<void> => {
   const response = await fetch(url, {
     method: 'PATCH',
-    headers: {
+    headers: withRequestIdHeader({
       'Content-Type': 'application/json',
       Authorization: `JWT ${makeJWT({ env })}`,
-    },
+    }),
     body: JSON.stringify(payload),
   });
 
@@ -63,10 +64,10 @@ export const postScannerResult = async ({
 }: PostScannerResultParams): Promise<void> => {
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
+    headers: withRequestIdHeader({
       'Content-Type': 'application/json',
       Authorization: `JWT ${makeJWT({ env })}`,
-    },
+    }),
     body: JSON.stringify(payload),
   });
 

--- a/src/functions/download.spec.ts
+++ b/src/functions/download.spec.ts
@@ -9,6 +9,10 @@ import {
   downloadFile,
   downloadFileUpload,
 } from './download';
+import {
+  AMO_REQUEST_ID_HEADER,
+  requestContextStorage,
+} from './request-context';
 
 describe(__filename, () => {
   describe('DownloadFileError', () => {
@@ -96,6 +100,37 @@ describe(__filename, () => {
         .calls[0];
       expect(calledURL).toEqual(downloadURL);
       expect(calledOptions.headers.Authorization).toMatch(/^JWT /);
+    });
+
+    it('sends the X-AMO-Request-ID header when a request ID is in scope', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: Readable.toWeb(Readable.from([Buffer.from('content')])),
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const requestId = 'req-123';
+      await requestContextStorage.run({ requestId }, () =>
+        downloadFile({ downloadURL, tmpDir, env }),
+      );
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers[AMO_REQUEST_ID_HEADER]).toEqual(requestId);
+    });
+
+    it('does not send the X-AMO-Request-ID header without a request ID', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: Readable.toWeb(Readable.from([Buffer.from('content')])),
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await downloadFile({ downloadURL, tmpDir, env });
+
+      const [, calledOptions] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledOptions.headers).not.toHaveProperty(AMO_REQUEST_ID_HEADER);
     });
 
     it('can use a custom filename', async () => {
@@ -206,7 +241,7 @@ describe(__filename, () => {
       const downloadedContent = fs.readFileSync(filepath, 'utf-8');
       expect(downloadedContent).toEqual(fileContent);
       expect(global.fetch).toHaveBeenCalledWith(validURL, {
-        headers: undefined,
+        headers: {},
       });
     });
 

--- a/src/functions/download.ts
+++ b/src/functions/download.ts
@@ -7,6 +7,7 @@ import type { ReadableStream } from 'node:stream/web';
 
 import { createAppError } from './error';
 import { makeJWT, MakeJWTConfig } from './auth';
+import { withRequestIdHeader } from './request-context';
 
 export const DEFAULT_DOWNLOAD_FILENAME = 'input.xpi';
 
@@ -47,10 +48,12 @@ const fetchToFile = async (
   downloadURL: string,
   tmpDir: string,
   filename: string,
-  headers?: HeadersInit,
+  headers?: Record<string, string>,
 ): Promise<string> => {
   try {
-    const response = await fetch(downloadURL, { headers });
+    const response = await fetch(downloadURL, {
+      headers: withRequestIdHeader(headers),
+    });
 
     if (!response.ok || !response.body) {
       throw new DownloadFileError(

--- a/src/functions/index.spec.ts
+++ b/src/functions/index.spec.ts
@@ -4,10 +4,12 @@ import express from 'express';
 import request from 'supertest';
 
 import {
+  AMO_REQUEST_ID_HEADER,
   FunctionConfig,
   RequestWithExtraProps,
   createAppError,
   createExpressApp,
+  getRequestId,
 } from '.';
 
 describe(__filename, () => {
@@ -45,6 +47,10 @@ describe(__filename, () => {
   describe('createExpressApp', () => {
     const testAllowedOrigin =
       'https://dont-use-this-subdomain.addons.mozilla.org';
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
     const createProcessWithEnv = (env = {}) => {
       return { ...process, env } as typeof process;
@@ -269,6 +275,55 @@ describe(__filename, () => {
         .send(JSON.stringify(body, null, 4));
 
       expect(response.status).toEqual(200);
+    });
+
+    it('exposes the X-AMO-Request-ID to the handler via the request context', async () => {
+      const requestId = 'req-xyz-789';
+      const requestIdHandler = (
+        req: RequestWithExtraProps,
+        res: express.Response,
+      ) => {
+        return res.json({
+          fromContext: getRequestId(),
+          fromRequest: req.amoRequestId,
+        });
+      };
+
+      const { app, sendApiKey } = _createExpressApp()(requestIdHandler);
+
+      const response = await sendApiKey(
+        request(app).post('/').set(AMO_REQUEST_ID_HEADER, requestId),
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        fromContext: requestId,
+        fromRequest: requestId,
+      });
+    });
+
+    it('generates a request ID when the X-AMO-Request-ID header is absent', async () => {
+      const generatedId = '11111111-2222-3333-4444-555555555555';
+      jest.spyOn(crypto, 'randomUUID').mockReturnValue(generatedId);
+
+      const requestIdHandler = (
+        req: RequestWithExtraProps,
+        res: express.Response,
+      ) => {
+        return res.json({
+          fromContext: getRequestId(),
+          fromRequest: req.amoRequestId,
+        });
+      };
+
+      const { app, sendApiKey } = _createExpressApp()(requestIdHandler);
+
+      const response = await sendApiKey(request(app).post('/'));
+
+      expect(response.status).toEqual(200);
+      // The generated ID is exposed both on the request and in the context.
+      expect(response.body.fromContext).toEqual(generatedId);
+      expect(response.body.fromRequest).toEqual(generatedId);
     });
 
     it('returns a 413 when the request body exceeds the configured limit', async () => {

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -10,6 +10,7 @@ import express, {
 import safeCompare from 'safe-compare';
 
 import { AppError, createAppError } from './error';
+import { requestIdMiddleware } from './request-context';
 
 /**
  * Express error handling middleware that serializes an {@link AppError} to a
@@ -32,8 +33,12 @@ export const createErrorHandler =
 
     res.status(err.status || 500).json(error);
 
-    // Also send the error to the cloud provider.
-    _console.error(error);
+    // Also send the error to the cloud provider, including the request ID for
+    // traceability when available.
+    _console.error({
+      ...error,
+      request_id: (req as RequestWithExtraProps).amoRequestId || null,
+    });
   };
 
 /**
@@ -42,9 +47,13 @@ export const createErrorHandler =
  *
  * @property rawBody - Raw request body buffer used for HMAC signature
  *   verification
+ * @property amoRequestId - Value of the incoming `X-AMO-Request-ID` header, or
+ *   a generated UUID when the header is absent. Exposed for convenience (e.g.
+ *   logging) in addition to being stored in the request context.
  */
 export type RequestWithExtraProps = Request & {
   rawBody?: Buffer;
+  amoRequestId?: string;
 };
 
 /**
@@ -121,6 +130,9 @@ export const createExpressApp =
 
     // Parse JSON body requests.
     app.use(express.json(jsonOptions));
+
+    // Capture the request ID and make it available for the rest of the chain.
+    app.use(requestIdMiddleware);
 
     // Authentication middleware plus some extra checks.
     app.use(
@@ -220,3 +232,4 @@ export * from './api';
 export * from './auth';
 export * from './download';
 export * from './error';
+export * from './request-context';

--- a/src/functions/request-context.spec.ts
+++ b/src/functions/request-context.spec.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto';
+
+import { NextFunction, Request, Response } from 'express';
+
+import {
+  AMO_REQUEST_ID_HEADER,
+  getRequestId,
+  requestIdMiddleware,
+  requestContextStorage,
+  withRequestIdHeader,
+} from './request-context';
+
+describe(__filename, () => {
+  describe('getRequestId', () => {
+    it('returns undefined when there is no active context', () => {
+      expect(getRequestId()).toBeUndefined();
+    });
+
+    it('returns the request ID from the active context', () => {
+      const requestId = 'abc-123';
+
+      requestContextStorage.run({ requestId }, () => {
+        expect(getRequestId()).toEqual(requestId);
+      });
+    });
+
+    it('returns undefined when the context has no request ID', () => {
+      requestContextStorage.run({}, () => {
+        expect(getRequestId()).toBeUndefined();
+      });
+    });
+  });
+
+  describe('withRequestIdHeader', () => {
+    it('adds the X-AMO-Request-ID header when a request ID is in scope', () => {
+      const requestId = 'abc-123';
+
+      requestContextStorage.run({ requestId }, () => {
+        expect(withRequestIdHeader({ Authorization: 'JWT token' })).toEqual({
+          Authorization: 'JWT token',
+          [AMO_REQUEST_ID_HEADER]: requestId,
+        });
+      });
+    });
+
+    it('returns the headers unchanged when there is no request ID', () => {
+      const headers = { Authorization: 'JWT token' };
+
+      requestContextStorage.run({}, () => {
+        expect(withRequestIdHeader(headers)).toEqual(headers);
+      });
+    });
+
+    it('returns the headers unchanged when there is no active context', () => {
+      const headers = { Authorization: 'JWT token' };
+
+      expect(withRequestIdHeader(headers)).toEqual(headers);
+    });
+
+    it('defaults to an empty set of headers', () => {
+      expect(withRequestIdHeader()).toEqual({});
+    });
+  });
+
+  describe('requestIdMiddleware', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const createReq = (headers: Record<string, string> = {}) =>
+      ({
+        get: (name: string) => headers[name],
+      }) as unknown as Request & { amoRequestId?: string };
+
+    it('exposes the incoming X-AMO-Request-ID on the request and context', () => {
+      const requestId = 'req-xyz-789';
+      const req = createReq({ [AMO_REQUEST_ID_HEADER]: requestId });
+      const next: NextFunction = jest.fn(() => {
+        expect(getRequestId()).toEqual(requestId);
+      });
+
+      requestIdMiddleware(req, {} as Response, next);
+
+      expect(req.amoRequestId).toEqual(requestId);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('generates a request ID when the header is absent', () => {
+      const generatedId = '11111111-2222-3333-4444-555555555555';
+      jest.spyOn(crypto, 'randomUUID').mockReturnValue(generatedId);
+      const req = createReq();
+      const next: NextFunction = jest.fn(() => {
+        expect(getRequestId()).toEqual(generatedId);
+      });
+
+      requestIdMiddleware(req, {} as Response, next);
+
+      expect(req.amoRequestId).toEqual(generatedId);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/functions/request-context.ts
+++ b/src/functions/request-context.ts
@@ -1,0 +1,62 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import crypto from 'node:crypto';
+
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+
+/**
+ * Name of the header carrying the unique request ID issued by AMO.
+ */
+export const AMO_REQUEST_ID_HEADER = 'X-AMO-Request-ID';
+
+/**
+ * Data kept around for the duration of a single request.
+ *
+ * @property requestId - The value of the incoming `X-AMO-Request-ID` header, or
+ *   a generated UUID when the header is absent.
+ */
+export type RequestContext = {
+  requestId?: string;
+};
+
+export const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Return the `X-AMO-Request-ID` of the request currently being handled, or
+ * `undefined` when there is no active request context (e.g. outside of the
+ * Express middleware chain).
+ */
+export const getRequestId = (): string | undefined =>
+  requestContextStorage.getStore()?.requestId;
+
+/**
+ * Return a copy of `headers` with the `X-AMO-Request-ID` header added when a
+ * request ID is available in the current context. When no request ID is in
+ * scope, `headers` is returned unchanged.
+ */
+export const withRequestIdHeader = (
+  headers: Record<string, string> = {},
+): Record<string, string> => {
+  const requestId = getRequestId();
+
+  return requestId
+    ? { ...headers, [AMO_REQUEST_ID_HEADER]: requestId }
+    : headers;
+};
+
+/**
+ * Express middleware that captures the AMO request ID from the incoming
+ * `X-AMO-Request-ID` header (generating a UUID when it is absent), exposes it
+ * on `req.amoRequestId`, and runs the rest of the middleware chain inside a
+ * request context so the ID stays available for the duration of the request
+ * and can be echoed back on every outgoing AMO API call.
+ */
+export const requestIdMiddleware: RequestHandler = (
+  req: Request & { amoRequestId?: string },
+  res: Response,
+  next: NextFunction,
+) => {
+  const requestId = req.get(AMO_REQUEST_ID_HEADER) ?? crypto.randomUUID();
+  req.amoRequestId = requestId;
+
+  requestContextStorage.run({ requestId }, () => next());
+};


### PR DESCRIPTION
refs https://github.com/mozilla/addons/issues/16279

---

This will allow us to pass a correlation ID between services. All
scanners written with this lib should get the feature for free.